### PR TITLE
fix cargo test-bpf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "solana_instruction_count"
+name = "ec_math"
 version = "0.1.0"
 authors = ["samkim-crypto <skim13@cs.stanford.edu>"]
 edition = "2018"
@@ -19,3 +19,5 @@ solana-program-test = "1.6.7"
 solana-sdk = "1.6.7"
 proptest = "0.10"
 
+[lib]
+crate-type = ["cdylib", "lib"]


### PR DESCRIPTION
Two things needed changing:

1. Your crate should be a "cdylib" so that the rust toolchain can output shared object files

I noticed that when running `cargo test-bpf` the following error message popped up:

```
Running: cargo-build-bpf --manifest-path /solana/tmp/ristretto-bpf-count/Cargo.toml --features test-bpf --bpf-out-dir /solana/tmp/ristretto-bpf-count/target/deploy
Note: solana_instruction_count crate does not contain a cdylib target
```

2. The crate name must match what's used in program setup

Note the below logs show this program is running natively rather than as interpreted bpf code.
```
running 1 test
[2021-05-20T12:43:36.646604000Z INFO  solana_program_test] "solana_instruction_count" program loaded as native code
[2021-05-20T12:43:36.770391000Z DEBUG solana_runtime::message_processor] Program log: Adding two u64 integers
[2021-05-20T12:43:36.770447000Z DEBUG solana_runtime::message_processor] Program log: SyscallStubs: sol_log_compute_units() not available
[2021-05-20T12:43:36.770463000Z DEBUG solana_runtime::message_processor] Program log: SyscallStubs: sol_log_compute_units() not available
[2021-05-20T12:43:36.770477000Z DEBUG solana_runtime::message_processor] Program log: 3
test test_ec_add ... ok
```